### PR TITLE
Switch fdb to ln003

### DIFF
--- a/notebooks/1_Data_Retrieval_from_FDB_Preprocessing.ipynb
+++ b/notebooks/1_Data_Retrieval_from_FDB_Preprocessing.ipynb
@@ -62,7 +62,7 @@
     "---\n",
     "type: remote\n",
     "engine: remote\n",
-    "host: balfrin-ln002.cscs.ch\n",
+    "host: balfrin-ln003.cscs.ch\n",
     "port: 30005\n",
     "store: remote\n",
     "\"\"\"\n",

--- a/notebooks/2_Precompute_and_Store_Echotop_to_FDB.ipynb
+++ b/notebooks/2_Precompute_and_Store_Echotop_to_FDB.ipynb
@@ -53,7 +53,7 @@
     "---\n",
     "type: remote\n",
     "engine: remote\n",
-    "host: balfrin-ln002.cscs.ch\n",
+    "host: balfrin-ln003.cscs.ch\n",
     "port: 30005\n",
     "store: remote\n",
     "\"\"\"\n",


### PR DESCRIPTION
FDB has been deployed to login node 3 instead of login node 2 on Balfrin due to instability issues with login node 2 lastly. Consequently, the configuration in the notebooks has been adjusted accordingly.